### PR TITLE
Hotfix/jobs are never failing due to the number of made attempts being updated after the new job is added to the retry queue.

### DIFF
--- a/lib/work_queue.js
+++ b/lib/work_queue.js
@@ -387,20 +387,18 @@ function retryOrDiscard(message, messageObject, deliveryInfo){
 
   var headers = messageObject.headers;
 
+  var madeAttempts = Number(headers.made_attempts) + 1;
+
   var job = this.createJob(headers.worker_id, message);
   job.maxRetry(headers.max_attempts)
-    .attempts(headers.made_attempts)
+    .attempts(madeAttempts)
     .backoff(headers.backoff)
     .delay(headers.delay)
     .sentAt(headers.sent_at);
 
-  var madeAttempts = Number(headers.made_attempts) + 1;
-
   var delayFunc = job._getBackoffImpl();
 
   var expiration = delayFunc(madeAttempts);
-
-  headers.made_attempts = madeAttempts;
 
   var messageOptions = {
     messageId: messageObject.messageId,


### PR DESCRIPTION
That is leading to the job always being retried.
